### PR TITLE
Added basic auth when in DEV mode

### DIFF
--- a/sa_site/.ebextensions/dev.config.template
+++ b/sa_site/.ebextensions/dev.config.template
@@ -28,4 +28,5 @@ files:
     content: |
       #!/usr/bin/env ruby
       require 'jumpcloud'
+      sleep(30)
       JumpCloud.set_system_tags('DEV Webserver')

--- a/sa_site/.ebextensions/prod.config.template
+++ b/sa_site/.ebextensions/prod.config.template
@@ -27,4 +27,5 @@ files:
     content: |
       #!/usr/bin/env ruby
       require 'jumpcloud'
+      sleep(30)
       JumpCloud.set_system_tags('PROD Webserver')

--- a/sa_site/Dockerfile
+++ b/sa_site/Dockerfile
@@ -26,6 +26,7 @@ RUN pecl install /etc/php5/elasticache.tar.gz
 
 # Copy config files in...
 COPY system/supervisor.conf /etc/supervisor/conf.d/sa_site.conf
+COPY system/apache2/keys.conf /etc/apache2/keys.conf
 COPY system/apache2/global.conf /etc/apache2/conf-available/sa_site.conf
 COPY system/apache2/vhost.conf /etc/apache2/sites-available/sa_site.conf
 COPY system/php5/elasticache.ini /etc/php5/mods-available/elasticache.ini
@@ -36,6 +37,7 @@ COPY system/php5-fpm/sa_site.conf /etc/php5/fpm/pool.d/sa_site.conf
 RUN a2enmod \
   actions \
   alias \
+  authn_file \
   env \
   proxy_fcgi \
   rewrite

--- a/sa_site/system/apache2/keys.conf
+++ b/sa_site/system/apache2/keys.conf
@@ -1,0 +1,1 @@
+demo:$apr1$UwvkNli5$Q5WZEuqNKZENHUov3uaub0

--- a/sa_site/system/apache2/vhost.conf
+++ b/sa_site/system/apache2/vhost.conf
@@ -6,7 +6,18 @@
     CustomLog ${APACHE_LOG_DIR}/sa_site.log common
 
     <Directory /opt/sa_site/website>
-        Require all granted
+        <If "env('ENVIRONMENT') == 'dev' && -T env('FORCE_AUTH')">
+            AuthType basic
+            AuthName "SportArchive Dev"
+            AuthBasicProvider file
+            AuthUserFile /etc/apache2/keys.conf
+
+            Require valid-user
+        </If>
+        <If "env('ENVIRONMENT') != 'dev' || ! -T env('FORCE_AUTH')">
+            Require all granted
+	</If>
+
         Options FollowSymLinks
         AllowOverride Limit FileInfo
     </Directory>


### PR DESCRIPTION
When in dev, add HTTP basic authentication to make sure outside users do
not get in. (Tried JumpCloud authentication but it proved a bit too
difficult and finicky to work properly.)

[Delivers #93111834]